### PR TITLE
refactor: mount under frontend-loader

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-frontend-loader
-version: 1.1.1
+version: 1.2.0
 crystal: ">= 1.0.0"
 license: MIT
 authors:

--- a/spec/root_spec.cr
+++ b/spec/root_spec.cr
@@ -4,12 +4,12 @@ module PlaceOS::FrontendLoader::Api
   describe Root do
     with_server do
       it "health checks" do
-        result = curl("GET", "/api/frontends/v1/")
+        result = curl("GET", "/api/frontend-loader/v1/")
         result.success?.should be_true
       end
 
       it "should check version" do
-        result = curl("GET", "/api/frontends/v1/version")
+        result = curl("GET", "/api/frontend-loader/v1/version")
         result.status_code.should eq 200
         PlaceOS::Model::Version.from_json(result.body).service.should eq "frontend-loader"
       end

--- a/src/placeos-frontend-loader/api/repositories.cr
+++ b/src/placeos-frontend-loader/api/repositories.cr
@@ -5,7 +5,7 @@ require "../loader"
 
 module PlaceOS::FrontendLoader::Api
   class Repositories < Base
-    base "/api/frontends/v1/repositories"
+    base "/api/frontend-loader/v1/repositories"
     Log = ::Log.for(self)
 
     # :nodoc:

--- a/src/placeos-frontend-loader/api/root.cr
+++ b/src/placeos-frontend-loader/api/root.cr
@@ -4,7 +4,7 @@ require "placeos-models/version"
 
 module PlaceOS::FrontendLoader::Api
   class Root < Base
-    base "/api/frontends/v1"
+    base "/api/frontend-loader/v1"
 
     get "/", :root do
       head :ok

--- a/src/placeos-frontend-loader/client.cr
+++ b/src/placeos-frontend-loader/client.cr
@@ -7,7 +7,7 @@ require "./error"
 
 module PlaceOS::FrontendLoader
   class Client
-    BASE_PATH   = "/api/frontends"
+    BASE_PATH   = "/api/frontend-loader"
     API_VERSION = "v1"
     DEFAULT_URI = URI.parse(ENV["PLACE_LOADER_URI"]? || "http://127.0.0.1:3000")
     getter api_version : String


### PR DESCRIPTION
API now mounted under `/api/frontend-loader/v1`